### PR TITLE
pdx206: Don't build libtinyxml

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -169,7 +169,6 @@ PRODUCT_PACKAGES += \
     libqdMetaData.system \
     libsdmcore \
     libsdmutils \
-    libtinyxml \
     memtrack.kona \
     vendor.display.config@1.11.vendor \
     vendor.display.config@2.0 \


### PR DESCRIPTION
Not used anywhere

Change-Id: I95d2296321b8f597fbf12bd3f57b4b2f512008f1